### PR TITLE
Draft updates to IPLD

### DIFF
--- a/draft-documents/ipld_did_documents.md
+++ b/draft-documents/ipld_did_documents.md
@@ -6,40 +6,23 @@
 
 Since the emergence of the Decentralized Identifier (DID) specification at the Fall 2016 Rebooting the Web of Trust, numerous DID method specifications have emerged. Each DID method specification defines how to resolve a cryptographically-tied DID document given a method-specific identifier. In this paper, we describe a way to represent an initial DID document as a directed acyclic graph via Interplanetary Linked Data (IPLD). This technique enables more cost-efficient, scaleable creation of DIDs and can be used across different DID method specifications.
 
-## Background / Definitions
+## Why IPLD
 
-> Note: it's possible we should work them into the doc but they seems a bit disjoint in the previous draft. I'm moving these up while working on the main doc flow and then we can determine how to merge them in.
+> I deleted definitions that didn't seem necessary. Double-check the result.
 
-> Some of these definitions don't seem necessary...
+[IPLD](https://ipld.io) is a way of representing hash-linked data to be used in content-addressed data retrieval systems like [IPFS](https://ipfs.io). IPLD enables creation of decentralized data-structures that are universally addressable and linkable. It achieves this through a data model enabling interoperability across protocol boundaries and formats. IPLD relies on [Content Identifiers (CIDs)](https://github.com/ipld/cid) for content addressing. CIDs are self-describing, flexible, and interoperable way of expressing cryptographic hashes. It uses several multiformats to achieve flexible self-description, namely multihash for hashes, multicodec for data content types, and multibase to encode the CID itself into strings.
 
-### IPLD
-
-[IPLD](https://ipld.io) is a way of representing hash-linked data to be used in content-addressed data retrieval systems like [IPFS](https://ipfs.io). 
-
-### CID
-
-[Content Identifiers (CIDs)](https://github.com/ipld/cid) are used for referencing content in distributed information systems, like IPFS. It leverages content addressing, cryptographic hashing, and self-describing formats. It is the core identifier used by IPFS and IPLD.  It uses cryptographic hashes to achieve content addressing. It uses several multiformats to achieve flexible self-description, namely multihash for hashes, multicodec for data content types, and multibase to encode the CID itself into strings.
-
-Anatomy of a CID: 
-`<mbase><version><mcodec><mhash>`
-
-Where:
-
-- `<mbase>` is a [multibase](multibase) prefix describing the base that encodes this CID. If binary, this is omitted.
-- `<version>` is the version number of the cid.
-- `<mcodec>` is a [multicodec-packed](https://github.com/multiformats/multicodec) identifier, from the CID multicodec table
-- `<mhash>` is a cryptographic [multihash](https://github.com/multiformats/multihash), including: `<mhash-code><mhash-len><mhash-value>`
-
-### CBOR 
-
-IPLD makes use of [Concise Binary Object Representation (CBOR)](http://cbor.io/). CBOR is a binary data serialization format loosely based on JSON. Its design goals include the possibility of extremely small code size, fairly small message size, and extensibility without the need for version negotiation.
+This interoperability makes IPLD a valuable structure for an initial DID document that can be used across a variety of DID methods and ledgers.
 
 ## Proposal
 
-We investigate using IPLD as a general pattern for DID creating in DID methods. The main idea is to represent an initial DID document as IPLD data, and then define the DID itself as the hash of this data. This way resolving the initial DID document from the DID is tautological - the DID is merely a representation of the data in the DID document.
+> TODO: need better/consistent terminology
 
-> 
-> TODO: what's the correct terminology for IPID DID Document?
+We describe how IPLD as a general pattern for DID creating in DID methods. 
+
+### Creation
+
+The main idea is to represent an initial DID document as IPLD data, and then define the DID itself as the hash of this data. This way resolving the initial DID document from the DID is tautological - the DID is merely a representation of the data in the DID document.
 
 The IPID DID document is not complete because the DID (identifier) will not be known at time of creation. This is a general issue for immutable storage of DID document material that is addressed by other DID methods during DID resolution. 
 
@@ -54,6 +37,13 @@ The initial DID document needs to contain information about where to discover th
 For instance, in the [muPort](https://github.com/uport-project/muport-core-js) DID method an Ethereum smart contract is used to point to the hash of the latest version of the DID document, and the document can be retrieved using the content-addressed IPFS system. In the [IPID](https://github.com/jonnycrunch/ipid) DID method the IPNS system can used to point to the latest version of the DID document, by means of a published signed statement. The [Sidetree](https://github.com/decentralized-identity/did-methods/blob/master/sidetrees/explainer.md) DID method uses a scalable Merkle data structure that aggregates multiple DID document updates in a Merkle Tree and publishes the root hash in a blockchain such as Bitcoin or Ethereum. A sidetree node can use these data structures to aggregate the updates into a complete DID document.
 
 One large advantage of the IPLD approach described here is that the identity owner does not need to use a blockchain when initially creating an identity, thus making creation of identities fast and low cost (if not free). The DID and DID document will be cryptographically coupled by hashing. Only when the identity owner needs to update their DID document will they need a more costly tool such as a blockchain.
+
+### Updates
+
+> TODO: merge some of the above into here
+
+TODO: must be signed by previous key (see diagram above).
+
 
 ## Examples
 
@@ -137,6 +127,7 @@ Example 1 shows the DID document before resolution. Note that `id` fields are om
 
 
 ## Uses / Examples
+
 ### Use for microledgers and pairwise identifiers
 
 The IPLD pattern may be good to use for pairwise identifiers. A pairwise identifier is a DID that is meant to be used only with one other entity. The idea is that when setting up a pairwise DID you can do it by generating the DID document, and send the DID as well as the DID document to the counterparty.

--- a/draft-documents/ipld_did_documents.md
+++ b/draft-documents/ipld_did_documents.md
@@ -4,13 +4,21 @@
 
 ## Abstract
 
-Numerous Decentralized Identifiers (DID) method specification have emerged since its introduction at a previous Rebooting the Web of Trust in 2016. Each DID method requires resolving a DID document that is cryptographically tied to the method specific identifier.  In this paper we present a generalized approach to resolve the DID document to a directed acyclic graph host on Interplanetary File System (IPFS) as an Interplanetary LInk Data (IPLD) node. 
+Since the emergence of the Decentralized Identifier (DID) specification at the Fall 2016 Rebooting the Web of Trust, numerous DID method specifications have emerged. Each DID method specification defines how to resolve a cryptographically-tied DID document given a method-specific identifier. In this paper, we describe a way to represent an initial DID document as a directed acyclic graph via Interplanetary Linked Data (IPLD). This technique enables more cost-efficient, scaleable creation of DIDs and can be used across different DID method specifications.
 
-## Background
+## Background / Definitions
 
-[IPLD](https://ipld.io) is a way of representing hash-linked data to be used in content-addressed data retrieval systems like [IPFS](https://ipfs.io). We investigate using IPLD as a general pattern in creating DID methods. The main idea is to represent an initial DID document as IPLD data, and then define the DID itself as the hash of this data. This way resolving the initial DID document from the DID is tautological - the DID is merely a representation of the data in the DID document.
+> Note: it's possible we should work them into the doc but they seems a bit disjoint in the previous draft. I'm moving these up while working on the main doc flow and then we can determine how to merge them in.
 
-Context Identifiers (CID) are used for referencing content in distributed information systems, like IPFS. It leverages content addressing, cryptographic hashing, and self-describing formats. It is the core identifier used by IPFS and IPLD.  It uses cryptographic hashes to achieve content addressing. It uses several multiformats to achieve flexible self-description, namely multihash for hashes, multicodec for data content types, and multibase to encode the CID itself into strings.
+> Some of these definitions don't seem necessary...
+
+### IPLD
+
+[IPLD](https://ipld.io) is a way of representing hash-linked data to be used in content-addressed data retrieval systems like [IPFS](https://ipfs.io). 
+
+### CID
+
+[Content Identifiers (CIDs)](https://github.com/ipld/cid) are used for referencing content in distributed information systems, like IPFS. It leverages content addressing, cryptographic hashing, and self-describing formats. It is the core identifier used by IPFS and IPLD.  It uses cryptographic hashes to achieve content addressing. It uses several multiformats to achieve flexible self-description, namely multihash for hashes, multicodec for data content types, and multibase to encode the CID itself into strings.
 
 Anatomy of a CID: 
 `<mbase><version><mcodec><mhash>`
@@ -21,13 +29,70 @@ Where:
 - `<version>` is the version number of the cid.
 - `<mcodec>` is a [multicodec-packed](https://github.com/multiformats/multicodec) identifier, from the CID multicodec table
 - `<mhash>` is a cryptographic [multihash](https://github.com/multiformats/multihash), including: `<mhash-code><mhash-len><mhash-value>`
-  
-## CBOR 
 
-IPLD makes uses Concise Binary Object Representation (CBOR).  is a binary data serialization format loosely based on JSON is a data format whose design goals include the possibility of extremely small code size, fairly small message size, and extensibility without the need for version negotiation.
+### CBOR 
+
+IPLD makes use of [Concise Binary Object Representation (CBOR)](http://cbor.io/). CBOR is a binary data serialization format loosely based on JSON. Its design goals include the possibility of extremely small code size, fairly small message size, and extensibility without the need for version negotiation.
+
+## Proposal
+
+We investigate using IPLD as a general pattern for DID creating in DID methods. The main idea is to represent an initial DID document as IPLD data, and then define the DID itself as the hash of this data. This way resolving the initial DID document from the DID is tautological - the DID is merely a representation of the data in the DID document.
+
+> 
+> TODO: what's the correct terminology for IPID DID Document?
+
+The IPID DID document is not complete because the DID (identifier) will not be known at time of creation. This is a general issue for immutable storage of DID document material that is addressed by other DID methods during DID resolution. 
+
+We address this by including _at most_ the [DID fragment](https://w3c-ccg.github.io/did-spec/#dfn-did-fragment), which is the part of the DID identifier after `#`, in the relevant DID document fields, which include `id`, `creator`, and key material. We may omit these fields entirely if there is no DID fragment to include, since this is optional. At resolution time, the resolver applies these missing fields from the DID identifier itself. (Note this is similar to the BTCR resolver merging implicit tx data with explicit DID document data, which doesn't know the DID at time of creation)
+
+As it stands this is also not a self-contained DID method because the DID document is immutable. Modifying the DID document would modify its hash, thus creating a new DID. We can however create a new DID document and link it back to the initial DID document, thus creating a cryptographic link back to the original DID. 
+
+![](ipld_did_documents/did_docs.png)
+
+The initial DID document needs to contain information about where to discover the latest version of the DID document (which is a requirement of DID resolution), but method specs can implement this in their own ways. 
+
+For instance, in the [muPort](https://github.com/uport-project/muport-core-js) DID method an Ethereum smart contract is used to point to the hash of the latest version of the DID document, and the document can be retrieved using the content-addressed IPFS system. In the [IPID](https://github.com/jonnycrunch/ipid) DID method the IPNS system can used to point to the latest version of the DID document, by means of a published signed statement. The [Sidetree](https://github.com/decentralized-identity/did-methods/blob/master/sidetrees/explainer.md) DID method uses a scalable Merkle data structure that aggregates multiple DID document updates in a Merkle Tree and publishes the root hash in a blockchain such as Bitcoin or Ethereum. A sidetree node can use these data structures to aggregate the updates into a complete DID document.
+
+One large advantage of the IPLD approach described here is that the identity owner does not need to use a blockchain when initially creating an identity, thus making creation of identities fast and low cost (if not free). The DID and DID document will be cryptographically coupled by hashing. Only when the identity owner needs to update their DID document will they need a more costly tool such as a blockchain.
+
+## Examples
+
+Example 1 shows the DID document before resolution. Note that `id` fields are omitted.
+
+**Example 1: IPLD DID document stored in IPFS**
+
+```
+{
+  "@context": {
+    "/": "zdpuAmoZixxJjvosviGeYcqduzDhSwGV2bL6ZTTXo1hbEJHfq"
+  },
+  "authentication": {
+      "type": "EdDsaSASignatureAuthentication2018", 
+      "publicKey": [
+          "did:ipid:QmcEF77C6QKj6Rzru7MR2N5tSM33PHQYEqXYzQuVHHAvvv" <<<< ?
+      ]
+  },
+  "created": "2018-07-14T17:00:00Z",
+  "previous": {
+    "/": "zdpuArY8PA81cxdoNqsP42xT5itMHi6savk7GReyaVxBoCgkv"
+  },
+  "proof" : {
+    "/": "z43AaGF42R2DXsU65bNnHRCypLPr9sg6D7CUws5raiqATVaB1jj"
+  },
+  "publicKey": [
+    {
+      "curve": "ed25519",
+      "expires": "2019-07-08T16:02:20Z",
+      "publicKeyBase64": "lji9qTtkCydxtez/bt1zdLxVMMbz4SzWvlqgOBmURoM=",
+      "type": "EdDsaPublicKey"
+    }
+  ],
+  "updated": "2018-07-09T02:41:00Z"
+}
+ 
+```
   
-  
-**Example DID document stored on IPLD:**
+**Example 2: final (after resolution) DID document**
 ```
 {
   "@context": {
@@ -70,15 +135,6 @@ IPLD makes uses Concise Binary Object Representation (CBOR).  is a binary data s
  
 ```
 
-Note that the DID document is not complete since in this case the DID document cannot contain the DID itself. A placeholder such as `did:example:this` would need to be put in whenever the DID appears in the DID document, but it is trivial to derive the complete DID document from the template.
-
-As it stands this is also not a self-contained DID method because the DID document is immutable. Modifying the DID document would modify its hash, thus creating a new DID. We can however create a new DID document and link it back to the initial DID document, thus creating a cryptographic link back to the original DID.
-
-The initial DID document needs to contain information about where to discover the latest version of the DID document. For instance, in the [muPort](https://github.com/uport-project/muport-core-js) DID method an Ethereum smart contract is used to point to the hash of the latest version of the DID document, and the document can be retrieved using the content-addressed IPFS system. In the [IPID](https://github.com/jonnycrunch/ipid) DID method the IPNS system can used to point to the latest version of the DID document, by means of a published signed statement. The [Sidetree](https://github.com/decentralized-identity/did-methods/blob/master/sidetrees/explainer.md) DID method uses a scalable Merkle data structure that aggregates multiple DID document updates in a Merkle Tree and publishes the root hash in a blockchain such as Bitcoin or Ethereum. A sidetree node can use these data structures to aggregate the updates into a complete DID document.
-
-![](ipld_did_documents/did_docs.png)
-
-One large advantage of the IPLD approach described here is that the identity owner does not need to use a blockchain when initially creating an identity, thus making creation of identities fast and low cost (if not free). The DID and DID document will be cryptographically coupled by hashing. Only when the identity owner needs to update their DID document will they need a more costly tool such as a blockchain.
 
 ## Uses / Examples
 ### Use for microledgers and pairwise identifiers

--- a/draft-documents/ipld_did_documents.md
+++ b/draft-documents/ipld_did_documents.md
@@ -30,26 +30,24 @@ We address this by including _at most_ the [DID fragment](https://w3c-ccg.github
 
 As it stands this is also not a self-contained DID method because the DID document is immutable. Modifying the DID document would modify its hash, thus creating a new DID. We can however create a new DID document and link it back to the initial DID document, thus creating a cryptographic link back to the original DID. 
 
-![](ipld_did_documents/did_docs.png)
-
 The initial DID document needs to contain information about where to discover the latest version of the DID document (which is a requirement of DID resolution), but method specs can implement this in their own ways. 
 
 For instance, in the [muPort](https://github.com/uport-project/muport-core-js) DID method an Ethereum smart contract is used to point to the hash of the latest version of the DID document, and the document can be retrieved using the content-addressed IPFS system. In the [IPID](https://github.com/jonnycrunch/ipid) DID method the IPNS system can used to point to the latest version of the DID document, by means of a published signed statement. The [Sidetree](https://github.com/decentralized-identity/did-methods/blob/master/sidetrees/explainer.md) DID method uses a scalable Merkle data structure that aggregates multiple DID document updates in a Merkle Tree and publishes the root hash in a blockchain such as Bitcoin or Ethereum. A sidetree node can use these data structures to aggregate the updates into a complete DID document.
 
+While the exact update details are up to the method spec, example 1 shows how the resulting structure might appear.
+
+**Example 1: Demonstration of updates**
+
+![](ipld_did_documents/did_docs.png)
+
 One large advantage of the IPLD approach described here is that the identity owner does not need to use a blockchain when initially creating an identity, thus making creation of identities fast and low cost (if not free). The DID and DID document will be cryptographically coupled by hashing. Only when the identity owner needs to update their DID document will they need a more costly tool such as a blockchain.
-
-### Updates
-
-> TODO: merge some of the above into here
-
-TODO: must be signed by previous key (see diagram above).
 
 
 ## Examples
 
-Example 1 shows the DID document before resolution. Note that `id` fields are omitted.
+Example 2 shows the DID document before resolution. Note that `id` fields are omitted.
 
-**Example 1: IPLD DID document stored in IPFS**
+**Example 2: IPLD DID document stored in IPFS**
 
 ```
 {
@@ -82,7 +80,7 @@ Example 1 shows the DID document before resolution. Note that `id` fields are om
  
 ```
   
-**Example 2: final (after resolution) DID document**
+**Example 3: final (after resolution) DID document**
 ```
 {
   "@context": {


### PR DESCRIPTION
I'm not sure where you all are leaning on some details. Some questions:

## Placeholder ids

Reading the part about not knowing the DID up front, I added details about how it can be done here. The recommended way is to include just the fragment, if present. The question is what happens after that. 

The options I'm aware of are:

1. Merge ids into the document during resolution: In BTCR we handle it during resolution time by merging in the known DID identifier with the document.

2. Update afterward by signing the DID document with the public keys from the first doc

I'm inclined to think that you want to reserve (2) for actual DID updates.

## Signatures

The above issue makes `signature` in the DID doc confusing as well. For BTCR, if the DID docu is in an immutable store, we consider the signature on the tx as sufficient. But that's because we also give special powers to the tx signing key (we give it authentication power by default, for example)

You could also just include a signature on the partial document, which doesn't apply to the resolved document (i.e. it's just self-signing the partial doc).

Where we go with this depends on whether there's any default behavior you want to enable (as with BTCR)

## Updates

I clarified one of my assumptions, which is that exact requirements of DID methods (updates, etc) are up to the individual method spec. I believe that this imposes no specific requirements beyond what the method spec defines. But I'm still thinking this through.